### PR TITLE
Add SKIP_ON_ERROR option to handle git push errors gracefully

### DIFF
--- a/update-vibe-badge.sh
+++ b/update-vibe-badge.sh
@@ -8,6 +8,7 @@ BADGE_COLOR="${BADGE_COLOR:-ff69b4}"
 BADGE_TEXT="${BADGE_TEXT:-Vibe_Coded}"
 COMMIT_MESSAGE="${COMMIT_MESSAGE:-Update vibe-coded badge}"
 DEBUG="${DEBUG:-false}"
+SKIP_ON_ERROR="${SKIP_ON_ERROR:-true}"
 
 # Parse debug flag from environment or command line
 if [[ "${1:-}" == "--debug" || "${1:-}" == "-d" || "$DEBUG" == "true" ]]; then
@@ -275,7 +276,15 @@ if ! $DEBUG; then
       
       # Push the changes if we're in GitHub Actions
       if [ -n "${GITHUB_ACTIONS:-}" ]; then
-        git push origin HEAD
+        if [ "$SKIP_ON_ERROR" = "true" ]; then
+          if ! git push origin HEAD 2>/dev/null; then
+            echo "Warning: Failed to push changes to remote. This is usually caused by concurrent updates."
+            echo "The badge has been updated locally but not pushed to the remote repository."
+            echo "Set SKIP_ON_ERROR=false to fail on push errors instead of skipping."
+          fi
+        else
+          git push origin HEAD
+        fi
       fi
     else
       BADGE_CHANGED=false


### PR DESCRIPTION
## Summary
- Introduces a new environment variable `SKIP_ON_ERROR` to control behavior on git push failures
- Default behavior is to skip errors and log a warning instead of failing the script
- Provides an option to fail on push errors by setting `SKIP_ON_ERROR=false`

## Changes

### Script Update
- Added `SKIP_ON_ERROR` variable with default value `true`
- Modified git push logic to:
  - Attempt to push changes
  - If push fails and `SKIP_ON_ERROR` is `true`, log a warning and continue without failing
  - If `SKIP_ON_ERROR` is `false`, allow the push error to fail the script

### Error Handling
- Handles concurrent update errors gracefully by skipping push failures
- Provides clear warning messages to inform users about skipped push errors and how to change this behavior

## Test plan
- [x] Verify that with default `SKIP_ON_ERROR=true`, push errors do not fail the script
- [x] Verify that setting `SKIP_ON_ERROR=false` causes the script to fail on push errors
- [x] Confirm warning messages appear correctly when push is skipped
- [x] Test behavior in GitHub Actions environment to ensure proper push handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/779f572e-316e-4147-8e97-a96bdfa53afc