### PR TITLE
Skip merge commits in update-vibe-badge.sh blame processing

### DIFF
--- a/update-vibe-badge.sh
+++ b/update-vibe-badge.sh
@@ -62,6 +62,15 @@ for FILE in $SOURCE_FILES; do
         AUTHOR_EMAIL=$(echo "$BLAME_INFO" | grep "^author-mail " | cut -d' ' -f2- | tr -d '<>')
         COMMIT_HASH=$(echo "$BLAME_INFO" | head -n1 | cut -d' ' -f1)
         
+        # Skip merge commits (commits with more than one parent)
+        if [ -n "$COMMIT_HASH" ] && [ "$COMMIT_HASH" != "0000000000000000000000000000000000000000" ]; then
+          PARENT_COUNT=$(git rev-list --parents -n 1 "$COMMIT_HASH" 2>/dev/null | wc -w)
+          # If parent count > 2 (commit hash + 2 or more parents), it's a merge commit
+          if [ "$PARENT_COUNT" -gt 2 ]; then
+            continue
+          fi
+        fi
+        
         # Skip empty lines and obvious boilerplate
         if [[ -n "$(echo "$LINE" | tr -d '[:space:]')" ]] && 
            [[ ! "$LINE" =~ ^[[:space:]]*# ]] && 


### PR DESCRIPTION
## Summary
- Enhances the `update-vibe-badge.sh` script to ignore merge commits when processing blame information
- Prevents merge commits (commits with multiple parents) from affecting the badge update logic

## Changes

### Script Update
- Added logic to detect merge commits by checking the number of parents of each commit hash
- Skips processing lines associated with merge commits to ensure only relevant commits are considered

## Test plan
- Verified that merge commits are correctly identified and skipped during blame processing
- Confirmed that the script continues to process non-merge commits as expected
- Ensured no disruption to existing functionality of the badge update script

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9bb22643-0f0f-412b-9f52-45b56d77bce8