### PR TITLE
feat: add Gemini AI detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is part of a suite of tools designed for the emerging world of **vi
 
 ## Features
 
-- **Smart AI Detection**: Identifies commits from Claude, Cursor, Zed, Windsurf, OpenAI, Codex, and various bots
+- **Smart AI Detection**: Identifies commits from Claude, Cursor, Zed, Windsurf, OpenAI, Codex, Gemini, and various bots
 - **Dynamic Logo Selection**: Automatically chooses the logo based on which AI tool contributed the most
 - **Flexible Configuration**: Customizable badge style, colors, text, and target file
 - **Debug Mode**: Detailed analysis of commit classification
@@ -94,6 +94,7 @@ The action identifies AI-generated code by analyzing git blame data:
    - Zed
    - Windsurf
    - OpenAI
+   - Gemini (Google)
    - Various bot accounts
 3. **Line Filtering**: Filters out boilerplate lines (comments, empty lines, imports) for accuracy
 4. **File Type Support**: Analyzes source files across multiple programming languages
@@ -108,6 +109,7 @@ The badge automatically selects the appropriate logo based on which AI tool has 
 - **Windsurf** → `windsurf` logo
 - **Cursor** → `githubcopilot` logo
 - **Zed** → `zedindustries` logo
+- **Gemini** → `google` logo
 - **Renovate** → `renovatebot` logo
 - **Semantic Release** → `semanticrelease` logo
 - **Other Bots** → `githubactions` logo
@@ -156,6 +158,9 @@ git config --global alias.windsurf-commit '!f() { msg="$1"; shift 1; git -c user
 
 # OpenAI Codex commits
 git config --global alias.openai-commit '!f() { msg="$1"; shift 1; git -c user.name="OpenAI Codex" -c user.email="noreply@openai.com" -c commit.gpgsign=false commit -m "$msg" -m "Signed-off-by: $(git config user.name) <$(git config user.email)>" "$@"; }; f'
+
+# Gemini commits
+git config --global alias.gemini-commit '!f() { msg="$1"; shift 1; git -c user.name="Gemini" -c user.email="noreply@google.com" -c commit.gpgsign=false commit -m "$msg" -m "Signed-off-by: $(git config user.name) <$(git config user.email)>" "$@"; }; f'
 ```
 
 ### Usage

--- a/update-vibe-badge.sh
+++ b/update-vibe-badge.sh
@@ -26,6 +26,7 @@ WINDSURF_LINES=0
 ZED_LINES=0
 OPENAI_LINES=0
 TERRAGON_LINES=0
+GEMINI_LINES=0
 BOT_LINES=0
 RENOVATE_LINES=0
 SEMANTIC_LINES=0
@@ -118,6 +119,11 @@ for FILE in $SOURCE_FILES; do
             AI_TYPE="OpenAI"
             OPENAI_LINES=$((OPENAI_LINES + 1))
             IS_AI=true
+          # Check for Gemini
+          elif echo "$AUTHOR" | grep -i 'gemini' >/dev/null || echo "$AUTHOR_EMAIL" | grep -E 'noreply@google\.com' >/dev/null; then
+            AI_TYPE="Gemini"
+            GEMINI_LINES=$((GEMINI_LINES + 1))
+            IS_AI=true
           # Check for bots
           elif echo "$AUTHOR" | grep -i '\[bot\]' >/dev/null || echo "$AUTHOR" | grep -iE 'renovate|semantic-release'; then
             if echo "$AUTHOR" | grep -i 'renovate' >/dev/null; then
@@ -185,6 +191,11 @@ if [ "$OPENAI_LINES" -gt "$MAX_COUNT" ]; then
   LOGO="openai"
   DOMINANT_AI="OpenAI"
 fi
+if [ "$GEMINI_LINES" -gt "$MAX_COUNT" ]; then
+  MAX_COUNT="$GEMINI_LINES"
+  LOGO="google"
+  DOMINANT_AI="Gemini"
+fi
 if [ "$BOT_LINES" -gt "$MAX_COUNT" ]; then
   MAX_COUNT="$BOT_LINES"
   LOGO="githubactions"
@@ -216,6 +227,7 @@ if $DEBUG; then
   [ "$WINDSURF_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Windsurf" "$WINDSURF_LINES"
   [ "$ZED_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Zed" "$ZED_LINES"
   [ "$OPENAI_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "OpenAI" "$OPENAI_LINES"
+  [ "$GEMINI_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Gemini" "$GEMINI_LINES"
   [ "$BOT_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Bot" "$BOT_LINES"
   [ "$RENOVATE_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Renovate" "$RENOVATE_LINES"
   [ "$SEMANTIC_LINES" -gt 0 ] && printf "  %-10s: %d lines\n" "Semantic" "$SEMANTIC_LINES"


### PR DESCRIPTION
## Summary
- Added detection for Gemini AI commits to the vibe-coded badge action
- Recognizes commits authored by "Gemini" with email "noreply@google.com"
- Uses Google logo when Gemini is the dominant AI contributor

## Implementation
The changes follow the existing pattern for AI detection in `update-vibe-badge.sh`:
- Added `GEMINI_LINES` counter initialization
- Added detection logic checking for "Gemini" in author name or "noreply@google.com" in email
- Added Gemini to the logo selection logic (uses "google" logo)
- Added Gemini to the debug output display

## Test plan
- [x] Verified script syntax with `bash -n`
- [x] Ran script in debug mode to confirm no errors
- [ ] Test with a repository containing actual Gemini commits

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)