### PR TITLE
docs: cross-link YOLO (AI agent launcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is part of a suite of tools designed for the emerging world of **vi
 - **[ai-aligned-git](https://github.com/trieloff/ai-aligned-git)** - A humorous Git wrapper that ensures AI coding agents maintain clean, attributed commits and follow best practices
 - **[ai-aligned-gh](https://github.com/trieloff/ai-aligned-gh)** - A transparent GitHub CLI wrapper that automatically detects AI tool usage and ensures proper bot attribution for GitHub actions
 - **[gh-workflow-peek](https://github.com/trieloff/gh-workflow-peek)** - A GitHub CLI extension for intelligently filtering workflow errors, perfect for AI agents working with limited context windows
+- **[yolo](https://github.com/trieloff/yolo)** - A portable AI agent launcher that adds the right bypass flags and supports isolated git worktrees for safe experimentation
 
 ## Features
 


### PR DESCRIPTION
Add a link to https://github.com/trieloff/yolo in the related projects/ecosystem section to help users discover the AI agent launcher that adds appropriate bypass flags and supports isolated git worktrees.