### PR TITLE
feat: add detection of "Pi" commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Part of the **[AI Ecoverse](https://github.com/ai-ecoverse/.github)** - a compre
 
 ## Features
 
-- **Smart AI Detection**: Identifies commits from Claude, Cursor, Zed, Windsurf, OpenAI, Codex, Gemini, Jules, Qwen, Amp, Droid, GitHub Copilot, Aider, Cline, Crush, Kimi, Goose, Grok, and various bots
+- **Smart AI Detection**: Identifies commits from Claude, Cursor, Zed, Windsurf, OpenAI, Codex, Gemini, Jules, Qwen, Amp, Droid, GitHub Copilot, Aider, Cline, Crush, Kimi, Goose, Grok, Pi, and various bots
 - **Dynamic Logo Selection**: Automatically chooses the logo based on which AI tool contributed the most
 - **Flexible Configuration**: Customizable badge style, colors, text, and target file
 - **Debug Mode**: Detailed analysis of commit classification
@@ -109,6 +109,7 @@ The action identifies AI-generated code by analyzing git blame data:
    - Kimi (Moonshot AI)
    - Goose (Block)
    - Terragon
+   - Pi (earendil.works)
    - Various bot accounts
 3. **Line Filtering**: Filters out boilerplate lines (comments, empty lines, imports) for accuracy
 4. **File Type Support**: Analyzes source files across multiple programming languages
@@ -135,6 +136,7 @@ The badge automatically selects the appropriate logo based on which AI tool has 
 - **Crush** → `robot` logo
 - **Kimi** → `openai` logo
 - **Goose** → `block` logo
+- **Pi** → `robot` logo
 - **Renovate** → `renovatebot` logo
 - **Semantic Release** → `semanticrelease` logo
 - **Other Bots** → `githubactions` logo

--- a/update-vibe-badge.sh
+++ b/update-vibe-badge.sh
@@ -27,7 +27,7 @@ declare -A AI_TYPE_LINES=(
   ["Claude"]=0 ["Cursor"]=0 ["Windsurf"]=0 ["Zed"]=0 ["OpenAI"]=0
   ["OpenCode"]=0 ["Terragon"]=0 ["Gemini"]=0 ["Qwen"]=0 ["Amp"]=0
   ["Droid"]=0 ["Copilot"]=0 ["Aider"]=0 ["Cline"]=0 ["Crush"]=0
-  ["Kimi"]=0 ["Goose"]=0 ["Grok"]=0 ["Bot"]=0 ["Renovate"]=0 ["Semantic"]=0 ["Jules"]=0
+  ["Kimi"]=0 ["Goose"]=0 ["Grok"]=0 ["Pi"]=0 ["Bot"]=0 ["Renovate"]=0 ["Semantic"]=0 ["Jules"]=0
 )
 
 # AI type to logo mapping
@@ -39,7 +39,7 @@ declare -A AI_LOGOS=(
   ["Gemini"]="google" ["Jules"]="google"
   ["Qwen"]="alibabacloud" ["Amp"]="sourcegraph"
   ["Droid"]="robot" ["Crush"]="robot"
-  ["Goose"]="block" ["Grok"]="xai" ["Renovate"]="renovatebot" ["Semantic"]="semanticrelease"
+  ["Goose"]="block" ["Grok"]="xai" ["Pi"]="robot" ["Renovate"]="renovatebot" ["Semantic"]="semanticrelease"
   ["Bot"]="githubactions"
 )
 
@@ -133,6 +133,8 @@ detect_ai_actor() {
     echo "Goose"; return 0
   elif echo "$actor_name" | grep -iw 'grok' >/dev/null || echo "$actor_email" | grep -E 'grok@x\.ai' >/dev/null; then
     echo "Grok"; return 0
+  elif echo "$actor_name" | grep -iw 'pi' >/dev/null || echo "$actor_email" | grep -E 'pi@earendil\.works' >/dev/null; then
+    echo "Pi"; return 0
   elif echo "$actor_name" | grep -i '\[bot\]' >/dev/null || echo "$actor_name" | grep -iE 'renovate|semantic-release' >/dev/null; then
     if echo "$actor_name" | grep -i 'renovate' >/dev/null; then
       echo "Renovate"; return 0


### PR DESCRIPTION
Add detection of "Pi" commits (author: Pi <pi@earendil.works>) so the vibe-coded badge attributes Pi-authored commits correctly.

- Added Pi to AI_TYPE_LINES and AI_LOGOS (using `robot` fallback logo, as no Pi-specific simpleicons slug exists; verified `pi` slug returns 404, `robot` is the honest fallback already used for Droid/Crush).
- Mirrored Grok pattern with `-iw` word-boundary grep to avoid substring matches like in "copilot".
- Updated detection in detect_ai_actor().
- Updated README lists for Smart AI Detection, AI Tool Detection, and Logo Selection.
- Verified detection logic with test cases for "Pi", "Copilot", "pip-bot".

This PR was authored by Pi while running inside the pi coding agent harness (third and final repo in the series).

Lars will review. Do not merge.